### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>9.4.0.M0</version>
+			<version>9.4.33.v20201020</version>
 		</dependency>		
 	</dependencies> 
 </project>


### PR DESCRIPTION
Fix for the Local Temp Directory Hijacking Vulnerability Issue
https://github.com/advisories/GHSA-g3wg-6mcf-8jj6

Solution:
Updated the org.eclipse.jetty:jetty-webapp version to 9.4.33.v20201020